### PR TITLE
Add uhal2.8.0 compatibility to the BUTextIO branch

### DIFF
--- a/include/BUTool/helpers/StatusDisplay/StatusDisplay.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplay.hh
@@ -1,12 +1,19 @@
 #ifndef __STATUS_DISPLAY_HH__
 #define __STATUS_DISPLAY_HH__
 
+#ifdef STD_UNORDERED_MAP
+#include <unordered_map>
+typedef std::unordered_map<std::string, std::string> uMap;
+#else 
+#include <boost/unordered_map.hpp>
+typedef boost::unordered_map<std::string, std::string> uMap;
+#endif
+
 #include <ostream>
 #include <iostream> //for std::cout
 #include <vector>
 #include <string>
 #include <map>
-#include <boost/unordered_map.hpp>
 #include <boost/tokenizer.hpp> //for tokenize
 
 #include "StatusDisplayMatrix.hh"

--- a/include/BUTool/helpers/StatusDisplay/StatusDisplayCell.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplayCell.hh
@@ -15,6 +15,7 @@ typedef boost::unordered_map<std::string, std::string> uMap;
 #include <string>
 #include <map>
 #include <boost/tokenizer.hpp> //for tokenizer
+#include <cmath> // for pow
 
 namespace BUTool{
 

--- a/include/BUTool/helpers/StatusDisplay/StatusDisplayCell.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplayCell.hh
@@ -1,13 +1,19 @@
 #ifndef __STATUS_DISPLAY_CELL_HH__
 #define __STATUS_DISPLAY_CELL_HH__
 
+#ifdef STD_UNORDERED_MAP
+#include <unordered_map>
+typedef std::unordered_map<std::string, std::string> uMap;
+#else 
+#include <boost/unordered_map.hpp>
+typedef boost::unordered_map<std::string, std::string> uMap;
+#endif
 
 #include <ostream>
 #include <iostream> //for std::cout
 #include <vector>
 #include <string>
 #include <map>
-#include <boost/unordered_map.hpp>
 #include <boost/tokenizer.hpp> //for tokenizer
 
 namespace BUTool{

--- a/include/BUTool/helpers/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplayMatrix.hh
@@ -1,12 +1,19 @@
 #ifndef __STATUS_DISPLAY_MATRIX_HH__
 #define __STATUS_DISPLAY_MATRIX_HH__
 
+#ifdef STD_UNORDERED_MAP
+#include <unordered_map>
+typedef std::unordered_map<std::string, std::string> uMap;
+#else 
+#include <boost/unordered_map.hpp>
+typedef boost::unordered_map<std::string, std::string> uMap;
+#endif
+
 #include <ostream>
 #include <iostream> //for std::cout
 #include <vector>
 #include <string>
 #include <map>
-#include <boost/unordered_map.hpp>
 #include <boost/tokenizer.hpp> //for tokenizer
 #include "StatusDisplayCell.hh"
 

--- a/include/BUTool/helpers/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplayMatrix.hh
@@ -38,7 +38,7 @@ namespace BUTool{
   public:
     StatusDisplayMatrix(){Clear();};
     ~StatusDisplayMatrix(){Clear();};
-    void Add(std::string  address,uint32_t value, uint32_t value_mask, boost::unordered_map<std::string,std::string> const & parameters);
+    void Add(std::string  address,uint32_t value, uint32_t value_mask, uMap const & parameters);
     void Render(std::ostream & stream,int status,StatusMode statusMode = TEXT) const;
     std::vector<std::string> GetTableRows() const;
     std::vector<std::string> GetTableColumns() const;
@@ -46,9 +46,9 @@ namespace BUTool{
  private:
     void Clear();
     void CheckName(std::string const & newName);
-    std::string ParseRow(boost::unordered_map<std::string,std::string> const & parameters,
+    std::string ParseRow(uMap const & parameters,
 			 std::string const & addressBase) const;
-    std::string ParseCol(boost::unordered_map<std::string,std::string> const & parameters,
+    std::string ParseCol(uMap const & parameters,
 			 std::string const & addressBase) const;
 
     std::vector<StatusDisplayCell*> row(std::string const &);

--- a/make/Makefile.x86
+++ b/make/Makefile.x86
@@ -73,6 +73,10 @@ CXX_FLAGS = -g -O3 -rdynamic -Wall -MMD -MP -fPIC ${INCLUDE_PATH} -Werror -Wno-l
 
 CXX_FLAGS += -std=c++11 -fno-omit-frame-pointer -pedantic -Wno-ignored-qualifiers -Werror=return-type -Wextra -Wno-long-long -Winit-self -Wno-unused-local-typedefs  -Woverloaded-virtual ${COMPILETIME_ROOT} ${FALLTHROUGH_FLAGS}
 
+ifeq (${STD_UNORDERED_MAP},1)
+	CXX_FLAGS += -DSTD_UNORDERED_MAP
+endif
+
 LINK_LIBRARY_FLAGS = -shared -fPIC -Wall -g -O3 -rdynamic ${LIBRARY_PATH} ${LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}
 
 LINK_EXECUTABLE_FLAGS = -Wall -g -O3 -rdynamic ${LIBRARY_PATH} ${EXECUTABLE_LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}

--- a/make/Makefile.x86
+++ b/make/Makefile.x86
@@ -73,8 +73,8 @@ CXX_FLAGS = -g -O3 -rdynamic -Wall -MMD -MP -fPIC ${INCLUDE_PATH} -Werror -Wno-l
 
 CXX_FLAGS += -std=c++11 -fno-omit-frame-pointer -pedantic -Wno-ignored-qualifiers -Werror=return-type -Wextra -Wno-long-long -Winit-self -Wno-unused-local-typedefs  -Woverloaded-virtual ${COMPILETIME_ROOT} ${FALLTHROUGH_FLAGS}
 
-ifeq (${STD_UNORDERED_MAP},1)
-	CXX_FLAGS += -DSTD_UNORDERED_MAP
+ifdef MAP_TYPE
+CXX_FLAGS += ${MAP_TYPE}
 endif
 
 LINK_LIBRARY_FLAGS = -shared -fPIC -Wall -g -O3 -rdynamic ${LIBRARY_PATH} ${LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}

--- a/src/helpers/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/helpers/StatusDisplay/StatusDisplayMatrix.cc
@@ -77,9 +77,9 @@ namespace BUTool{
     return rowColMap.at(row).at(col);
   }
 
-  void StatusDisplayMatrix::Add(std::string address,uint32_t value,uint32_t value_mask, boost::unordered_map<std::string,std::string> const & parameters)
+  void StatusDisplayMatrix::Add(std::string address,uint32_t value,uint32_t value_mask, uMap const & parameters)
   {
-    boost::unordered_map<std::string,std::string>::const_iterator itTable= parameters.find("Table");
+    uMap::const_iterator itTable= parameters.find("Table");
     if(itTable == parameters.end()){
       BUException::BAD_VALUE e;
       char tmp[256];
@@ -237,10 +237,10 @@ namespace BUTool{
     }      
   }
 
-  std::string StatusDisplayMatrix::ParseRow(boost::unordered_map<std::string,std::string> const & parameters,
+  std::string StatusDisplayMatrix::ParseRow(uMap const & parameters,
 					    std::string const & addressBase) const
   {
-    boost::unordered_map<std::string,std::string>::const_iterator rowName = parameters.find("Row");
+    uMap::const_iterator rowName = parameters.find("Row");
     std::string newRow;
     //Row
     if(rowName != parameters.end()){
@@ -295,10 +295,10 @@ namespace BUTool{
     }
     return newRow;
   }
-  std::string StatusDisplayMatrix::ParseCol(boost::unordered_map<std::string,std::string> const & parameters,
+  std::string StatusDisplayMatrix::ParseCol(uMap const & parameters,
 					 std::string const & addressBase) const
   {    
-    boost::unordered_map<std::string,std::string>::const_iterator colName = parameters.find("Column");
+    uMap::const_iterator colName = parameters.find("Column");
     std::string newCol;
     //Col
     if(colName != parameters.end()){


### PR DESCRIPTION
When building BUTool for the ApolloHerd plugin, provide the functionality to compile against uHAL 2.7.X or uHAL 2.8.0